### PR TITLE
Update: The-Browser.md

### DIFF
--- a/Level-0/00-Tools-of-the-Trade/The-Browser.md
+++ b/Level-0/00-Tools-of-the-Trade/The-Browser.md
@@ -56,7 +56,7 @@ website.
   parts are when using a URL. Here they are:
 
     * `http` or `https`
-        - This means Hyper Text Transfer Protocol or Hyper Text Transfer Protocol . A Protocol is a set of rules to be
+        - This means Hyper Text Transfer Protocol or Hyper Text Transfer Protocol Secure. A Protocol is a set of rules to be
         used by the browser when requesting and receiving information.
 
     * `:`


### PR DESCRIPTION
Path: developer-training-tools/Level-0/00-Tools-of-the-Trade/The-Browser.md
Line: 59

In defining "http" and "https" the line stated the definition for "http" twice and did not include "Secure" in the definition of "https".
I have edited the line to include "Secure" in "Hyper Text Transfer Protocol Secure"